### PR TITLE
WIP:Precision lattice

### DIFF
--- a/lettuce/equilibrium.py
+++ b/lettuce/equilibrium.py
@@ -20,7 +20,7 @@ class QuadraticEquilibrium(Equilibrium):
             [self.lattice.w,
              rho * ((2 * exu - uxu) / (2 * self.lattice.cs ** 2) + 0.5 * (exu / (self.lattice.cs ** 2)) ** 2 + 1)]
         )
-        return feq
+        return self.lattice.f_recentered(feq)
 
 
 class QuadraticEquilibrium_LessMemory(QuadraticEquilibrium):
@@ -33,13 +33,13 @@ class QuadraticEquilibrium_LessMemory(QuadraticEquilibrium):
     """
 
     def __call__(self, rho, u, *args):
-        return self.lattice.einsum(
+        return self.lattice.f_recentered( self.lattice.einsum(
             "q,q->q",
             [self.lattice.w,
              rho * ((2 * torch.tensordot(self.lattice.e, u, dims=1) - self.lattice.einsum("d,d->", [u, u]))
                     / (2 * self.lattice.cs ** 2)
                     + 0.5 * (torch.tensordot(self.lattice.e, u, dims=1) / (self.lattice.cs ** 2)) ** 2 + 1)]
-        )
+        ))
 
 
 class IncompressibleQuadraticEquilibrium(Equilibrium):
@@ -56,4 +56,5 @@ class IncompressibleQuadraticEquilibrium(Equilibrium):
              rho
              + self.rho0 * ((2 * exu - uxu) / (2 * self.lattice.cs ** 2) + 0.5 * (exu / (self.lattice.cs ** 2)) ** 2)]
         )
-        return feq
+        return self.lattice.f_recentered(feq)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 
 from lettuce import (
-    stencils, Stencil, get_subclasses, Transform, Lattice, moments
+    stencils, Stencil, get_subclasses, Transform, Lattice, moments, PrecisionLattice
 )
 
 STENCILS = list(get_subclasses(Stencil, stencils))
@@ -53,7 +53,7 @@ def f_lattice(lattice):
     return lattice.convert_to_tensor(np.random.random([lattice.Q] + [3] * lattice.D)), lattice
 
 
-@pytest.fixture(params=[Lattice])
+@pytest.fixture(params=[Lattice, PrecisionLattice])
 def f_all_lattices(request, lattice):
     """Run a test for all lattices and lattices-of-vector;
     return a grid with 3^D sample distribution functions alongside the lattice.


### PR DESCRIPTION
I am just showing this for our archives ^^

I tried implementing a version, where `f_i` is centered around 0 rather than `w_i` 
This ought to help numerical precision. It may be that I made a mistake or that the computation of the equilibrium needs to be improved in order for this change to be effective.

The "PrecisionLattice" and "Lattice" perform similar in double precision. In single precision, the recentered version is better in terms of pressure but **WORSE** in terms of velocity.

.... so: I'll leave this here for now but will delete the branch at some point.


Here are the numbers (on CUDA):

> lettuce -p single convergence
```
     resolution       error (u)       order (u)       error (p)       order (p)
             16        3.04e-02             0.0        2.24e-02             0.0
             32        6.83e-03             2.2        9.81e-03             1.1
             64        1.52e-03             2.2        4.73e-03             1.0
            128        3.54e-04             2.2        3.48e-03             0.7                                                                                                                            
            256        9.14e-05             1.9        2.28e-02             0.1
```

> lettuce -p single convergence --f-recentered
```
     resolution       error (u)       order (u)       error (p)       order (p) 
             16        3.04e-02             0.0        2.24e-02             0.0
             32        6.83e-03             2.2        9.80e-03             1.1
             64        1.52e-03             2.2        4.72e-03             1.0
            128        3.72e-04             2.0        2.76e-03             0.9
            256        1.53e-04             1.2        1.42e-02             0.1
```
