### PR TITLE
Lattice Symmetries

### DIFF
--- a/lettuce/collision.py
+++ b/lettuce/collision.py
@@ -3,17 +3,27 @@ Collision models
 """
 
 import torch
+import numpy as np
 
 from lettuce.equilibrium import QuadraticEquilibrium
 from lettuce.util import LettuceException
+from lettuce.moments import DEFAULT_TRANSFORM
+from lettuce.util import LettuceCollisionNotDefined
+from lettuce.stencils import D2Q9, D3Q27
 
 __all__ = [
-    "BGKCollision", "KBCCollision2D", "KBCCollision3D", "MRTCollision", "RegularizedCollision",
-    "SmagorinskyCollision", "TRTCollision", "BGKInitialization"
+    "Collision",
+    "BGKCollision", "KBCCollision2D", "KBCCollision3D", "MRTCollision",
+    "RegularizedCollision", "SmagorinskyCollision", "TRTCollision", "BGKInitialization"
 ]
 
 
-class BGKCollision:
+class Collision:
+    def __call__(self, f):
+        return NotImplemented
+
+
+class BGKCollision(Collision):
     def __init__(self, lattice, tau, force=None):
         self.force = force
         self.lattice = lattice
@@ -28,27 +38,38 @@ class BGKCollision:
         return f - 1.0 / self.tau * (f - feq) + Si
 
 
-class MRTCollision:
+class MRTCollision(Collision):
     """Multiple relaxation time collision operator
 
     This is an MRT operator in the most general sense of the word.
     The transform does not have to be linear and can, e.g., be any moment or cumulant transform.
     """
-
-    def __init__(self, lattice, transform, relaxation_parameters):
+    def __init__(self, lattice, relaxation_parameters, transform=None):
         self.lattice = lattice
-        self.transform = transform
-        self.relaxation_parameters = lattice.convert_to_tensor(relaxation_parameters)
+        if transform is None:
+            try:
+                self.transform = DEFAULT_TRANSFORM[lattice.stencil](lattice)
+            except KeyError:
+                raise LettuceCollisionNotDefined("No entry for stencil {lattice.stencil} in moments.DEFAULT_TRANSFORM")
+        else:
+            self.transform = transform
+        if isinstance(relaxation_parameters, float):
+            tau = relaxation_parameters
+            self.relaxation_parameters = lattice.convert_to_tensor(tau * np.ones(lattice.stencil.Q()))
+        else:
+            self.relaxation_parameters = lattice.convert_to_tensor(relaxation_parameters)
 
     def __call__(self, f):
         m = self.transform.transform(f)
+        #feq = self.lattice.equilibrium(self.lattice.rho(f), self.lattice.u(f))
+        #meq = self.transform.transform(feq)
         meq = self.transform.equilibrium(m)
         m = m - self.lattice.einsum("q,q->q", [1 / self.relaxation_parameters, m - meq])
         f = self.transform.inverse_transform(m)
         return f
 
 
-class TRTCollision:
+class TRTCollision(Collision):
     """Two relaxation time collision model - standard implementation (cf. Krüger 2017)
         """
 
@@ -69,7 +90,7 @@ class TRTCollision:
         return f
 
 
-class RegularizedCollision:
+class RegularizedCollision(Collision):
     """Regularized LBM according to Jonas Latt and Bastien Chopard (2006)"""
 
     def __init__(self, lattice, tau):
@@ -100,12 +121,13 @@ class RegularizedCollision:
         return f
 
 
-class KBCCollision2D:
+class KBCCollision2D(Collision):
     """Entropic multi-relaxation time model according to Karlin et al. in two dimensions"""
 
     def __init__(self, lattice, tau):
         self.lattice = lattice
-        assert lattice.Q == 9, LettuceException("KBC2D only realized for D2Q9")
+        if not lattice.stencil == D2Q9:
+            raise LettuceCollisionNotDefined("This implementation only works for the D2Q9 stencil.")
         self.tau = tau
         self.beta = 1. / (2 * tau)
 
@@ -178,12 +200,13 @@ class KBCCollision2D:
         return f
 
 
-class KBCCollision3D:
+class KBCCollision3D(Collision):
     """Entropic multi-relaxation time-relaxation time model according to Karlin et al. in three dimensions"""
 
     def __init__(self, lattice, tau):
         self.lattice = lattice
-        assert lattice.Q == 27, LettuceException("KBC only realized for D3Q27")
+        if not lattice.stencil == D3Q27:
+            raise LettuceCollisionNotDefined("This implementation only works for the D3Q27 stencil.")
         self.tau = tau
         self.beta = 1. / (2 * tau)
 
@@ -269,7 +292,7 @@ class KBCCollision3D:
         return f
 
 
-class SmagorinskyCollision:
+class SmagorinskyCollision(Collision):
     """Smagorinsky large eddy simulation (LES) collision model with BGK operator."""
 
     def __init__(self, lattice, tau, smagorinsky_constant=0.17, force=None):

--- a/lettuce/moments.py
+++ b/lettuce/moments.py
@@ -11,7 +11,7 @@ import numpy as np
 
 __all__ = [
     "moment_tensor", "get_default_moment_transform", "Moments", "Transform", "D1Q3Transform",
-    "D2Q9Lallemand", "D2Q9Dellar", "D3Q27Hermite"
+    "D2Q9Lallemand", "D2Q9Dellar", "D3Q27Hermite", "DEFAULT_TRANSFORM"
 ]
 
 _ALL_STENCILS = get_subclasses(Stencil, module=lettuce)
@@ -455,3 +455,10 @@ class D3Q27Hermite(Transform):
         meq[25] = jx * jy * jy * jz * jz / rho ** 4
         meq[26] = jx * jy * jx * jz * jy * jz / rho ** 5
         return meq
+
+
+DEFAULT_TRANSFORM = {
+    D1Q3: D1Q3Transform,
+    D2Q9: D2Q9Dellar,
+    D3Q27: D3Q27Hermite
+}

--- a/lettuce/symmetry.py
+++ b/lettuce/symmetry.py
@@ -1,6 +1,5 @@
 """Lattice Symmetries"""
 
-import copy
 import numpy as np
 
 
@@ -74,6 +73,7 @@ class ChainedSymmetry(Symmetry):
 class InverseSymmetry(Symmetry):
     """Inverse of a symmetry operation"""
     def __init__(self, delegate):
+        super().__init__()
         self.delegate = delegate
 
     def forward(self, x):
@@ -146,7 +146,10 @@ class Identity(Symmetry):
     def __repr__(self): return "<Identity>"
 
 
-class SymmetryGroup(set):
+class SymmetryGroup(list):
+    """
+    Lattice symmetry group.
+    """
     def __init__(self, stencil):
         super().__init__()
         self.stencil = stencil
@@ -155,8 +158,12 @@ class SymmetryGroup(set):
         while len(new_symmetries) > 0:
             for n in new_symmetries:
                 if n not in self:
-                    self.add(n)
+                    self.append(n)
             new_symmetries = self._new_symmetries(candidates)
+
+    @property
+    def permutations(self):
+        return np.stack([symmetry.permutation(self.stencil) for symmetry in self])
 
     def _new_symmetries(self, candidates):
         result = []

--- a/lettuce/symmetry.py
+++ b/lettuce/symmetry.py
@@ -1,0 +1,204 @@
+"""Lattice Symmetries"""
+
+import copy
+import numpy as np
+
+
+__all__ = [
+    "is_symmetry", "are_symmetries_equal", "Symmetry",
+    "SymmetryGroup", "InverseSymmetry", "ChainedSymmetry", "Identity",
+    "Rotation90", "Reflection"
+]
+
+
+def is_symmetry(operation, stencil):
+    "whether the operation leaves the stencil invariant"
+    original_e = set(tuple(e) for e in stencil.e)
+    new_e = set(tuple(operation.forward(e)) for e in stencil.e)
+    reverse_e = set(tuple(operation.inverse(e)) for e in stencil.e)
+    return original_e == new_e and original_e == reverse_e
+
+
+def are_symmetries_equal(symmetry1, symmetry2, stencil):
+    return np.allclose(symmetry1.forward(stencil.e), symmetry2.forward(stencil.e))
+
+
+class Symmetry:
+    """Abstract base class for symmetry operations."""
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return NotImplemented
+
+    def inverse(self, x):
+        return NotImplemented
+
+    def permutation(self, stencil):
+        assert is_symmetry(self, stencil)
+        other = self.forward(stencil.e)
+        return np.concatenate([np.where((ei == stencil.e).all(axis=-1))[0] for ei in other])
+
+
+class ChainedSymmetry(Symmetry):
+    """Stitch multiple symmetries together."""
+    def __init__(self, *symmetries):
+        super().__init__()
+        self.symmetries = symmetries
+        # unfold chains
+        for i, symmetry in enumerate(self.symmetries):
+            if isinstance(symmetry, ChainedSymmetry):
+                self.symmetries = (*self.symmetries[:i], *symmetry, *self.symmetries[i + 1:])
+        self.symmetries = tuple(self.symmetries)
+
+    def forward(self, x):
+        for s in self.symmetries:
+            x = s.forward(x)
+        return x
+
+    def inverse(self, x):
+        for s in reversed(self.symmetries):
+            x = s.inverse(x)
+        return x
+
+    def __iter__(self):
+        return self.symmetries.__iter__()
+
+    def __len__(self):
+        return self.symmetries.__len__()
+
+    def __repr__(self):
+        return f"<Chain: {[repr(s) for s in self.symmetries]})>"
+
+
+class InverseSymmetry(Symmetry):
+    """Inverse of a symmetry operation"""
+    def __init__(self, delegate):
+        self.delegate = delegate
+
+    def forward(self, x):
+        return self.delegate.inverse(x)
+
+    def inverse(self, x):
+        return self.delegate.forward(x)
+
+
+class Reflection(Symmetry):
+    """Reflection along one dimension."""
+    def __init__(self, dim):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, x):
+        y = x.copy()
+        y[..., self.dim] *= -1
+        return y
+
+    def inverse(self, x):
+        y = x.copy()
+        y[..., self.dim] *= -1
+        return y
+
+    def __repr__(self):
+        return f"<Reflection: {self.dim}>"
+
+
+class Rotation90(Symmetry):
+    """Counterclockwise rotation by 90 degrees."""
+    def __init__(self, *dims):
+        super().__init__()
+        self.dims = dims
+        self.mat = np.array(
+            [
+                [np.cos(np.pi/2), -np.sin(np.pi/2)],
+                [np.sin(np.pi/2), np.cos(np.pi/2)]
+            ], dtype=int
+        )
+
+    def forward(self, x):
+        y = x.copy()
+        y[..., [self.dims[0], self.dims[1]]] = np.einsum(
+            "ij,...i->...j",
+            self.mat,
+            y[..., [self.dims[0], self.dims[1]]]
+        )
+        return y
+
+    def inverse(self, x):
+        y = x.copy()
+        y[..., [self.dims[0], self.dims[1]]] = np.einsum(
+            "ji,...i->...j",
+            self.mat,
+            y[..., [self.dims[0], self.dims[1]]]
+        )
+        return y
+
+    def __repr__(self):
+        return f"<Rotation90: {self.dims}>"
+
+
+class Identity(Symmetry):
+    """The identity."""
+    def forward(self, x): return x
+
+    def inverse(self, x): return x
+
+    def __repr__(self): return "<Identity>"
+
+
+class SymmetryGroup(set):
+    def __init__(self, stencil):
+        super().__init__()
+        self.stencil = stencil
+        candidates = self._make_candidates(stencil.D())
+        new_symmetries = {Identity()}
+        while len(new_symmetries) > 0:
+            for n in new_symmetries:
+                if n not in self:
+                    self.add(n)
+            new_symmetries = self._new_symmetries(candidates)
+
+    def _new_symmetries(self, candidates):
+        result = []
+        for c in candidates:
+            for s in self:
+                proposed = self._chain_symmetries(s, c)
+                if proposed not in self:
+                    result.append(proposed)
+        return result
+
+    def __contains__(self, symmetry):
+        for elem in self:
+            if are_symmetries_equal(symmetry, elem, self.stencil):
+                return True
+        return False
+
+    @staticmethod
+    def _make_candidates(dim):
+        candidates = []
+        for i in range(dim):
+            for j in range(i + 1, dim):
+                candidates.append(Rotation90(i, j))
+        for i in range(dim):
+           candidates.append(Reflection(i))
+        # if for some reason we cannot reach all elements by 90-degree rotations
+        for i in range(dim):
+            for j in range(i + 1, dim):
+                # 180 degree rotations
+                candidates.append(ChainedSymmetry(Rotation90(i, j), Rotation90(i, j)))
+                # inverse rotations
+                candidates.append(InverseSymmetry(Rotation90(i,j)))
+        return candidates
+
+    def _chain_symmetries(self, *symmetries):
+        symmetries = [
+            s for s in symmetries
+            if not are_symmetries_equal(s, Identity(), self.stencil)
+        ]
+        if len(symmetries) == 0:
+            return Identity()
+        elif len(symmetries) == 1:
+            return symmetries[0]
+        else:
+            return ChainedSymmetry(*symmetries)
+

--- a/lettuce/util.py
+++ b/lettuce/util.py
@@ -6,12 +6,17 @@ import inspect
 import torch
 
 __all__ = [
-    "LettuceException", "LettuceWarning", "InefficientCodeWarning", "ExperimentalWarning",
+    "LettuceException", "LettuceCollisionNotDefined",
+    "LettuceWarning", "InefficientCodeWarning", "ExperimentalWarning",
     "get_subclasses", "torch_gradient", "torch_jacobi", "grid_fine_to_coarse", "pressure_poisson"
 ]
 
 
 class LettuceException(Exception):
+    pass
+
+
+class LettuceCollisionNotDefined(Exception):
     pass
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,9 +8,6 @@ exclude = docs
 # Define setup.py command aliases here
 test = pytest
 
-[tool:pytest]
-collect_ignore = ['setup.py']
-
 
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,12 @@ import numpy as np
 import torch
 
 from lettuce import (
-    stencils, Stencil, get_subclasses, Transform, Lattice, moments
+    stencils, Stencil, get_subclasses, Transform, Lattice, moments, collision, Collision
 )
 
 STENCILS = list(get_subclasses(Stencil, stencils))
 TRANSFORMS = list(get_subclasses(Transform, moments))
+COLLISION_MODELS = list(get_subclasses(Collision, collision))
 
 
 @pytest.fixture(
@@ -73,3 +74,9 @@ def f_transform(request, f_all_lattices):
         return f, Transform(lattice)
     else:
         pytest.skip("Stencil not supported for this transform.")
+
+
+@pytest.fixture(params=COLLISION_MODELS, scope="session")
+def Collision(request):
+    """Run a test for all stencils."""
+    return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def dtype_device(request, device):
     return request.param, device
 
 
-@pytest.fixture(params=STENCILS)
+@pytest.fixture(params=STENCILS, scope="session")
 def stencil(request):
     """Run a test for all stencils."""
     return request.param

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -8,28 +8,24 @@ import numpy as np
 from lettuce import *
 
 
-@pytest.mark.parametrize("Collision", [BGKCollision, KBCCollision2D, KBCCollision3D, TRTCollision, RegularizedCollision,
-                                       SmagorinskyCollision])
 def test_collision_conserves_mass(Collision, f_all_lattices):
     f, lattice = f_all_lattices
-    if ((Collision == KBCCollision2D and lattice.stencil != D2Q9) or (
-            (Collision == KBCCollision3D and lattice.stencil != D3Q27))):
+    try:
+        collision = Collision(lattice, 0.51)
+    except LettuceCollisionNotDefined:
         pytest.skip()
     f_old = copy(f)
-    collision = Collision(lattice, 0.51)
     f = collision(f)
     assert lattice.rho(f).cpu().numpy() == pytest.approx(lattice.rho(f_old).cpu().numpy())
 
 
-@pytest.mark.parametrize("Collision", [BGKCollision, KBCCollision2D, KBCCollision3D, TRTCollision, RegularizedCollision,
-                                       SmagorinskyCollision])
 def test_collision_conserves_momentum(Collision, f_all_lattices):
     f, lattice = f_all_lattices
-    if ((Collision == KBCCollision2D and lattice.stencil != D2Q9) or (
-            (Collision == KBCCollision3D and lattice.stencil != D3Q27))):
+    try:
+        collision = Collision(lattice, 0.51)
+    except LettuceCollisionNotDefined:
         pytest.skip()
     f_old = copy(f)
-    collision = Collision(lattice, 0.51)
     f = collision(f)
     assert lattice.j(f).cpu().numpy() == pytest.approx(lattice.j(f_old).cpu().numpy(), abs=1e-5)
 
@@ -43,22 +39,22 @@ def test_collision_fixpoint_2x(Collision, f_all_lattices):
     assert f.cpu().numpy() == pytest.approx(f_old.cpu().numpy(), abs=1e-5)
 
 
-@pytest.mark.parametrize("Collision",
-                         [BGKCollision, TRTCollision, KBCCollision2D, KBCCollision3D, RegularizedCollision])
 def test_collision_relaxes_shear_moments(Collision, f_all_lattices):
     """checks whether the collision models relax the shear moments according to the prescribed relaxation time"""
     f, lattice = f_all_lattices
-    if ((Collision == KBCCollision2D and lattice.stencil != D2Q9) or (
-            (Collision == KBCCollision3D and lattice.stencil != D3Q27))):
+    tau = 0.6
+    try:
+        collision = Collision(lattice, tau)
+    except LettuceCollisionNotDefined:
         pytest.skip()
+    if Collision == SmagorinskyCollision:
+        pytest.skip("Introduces additional viscosity.")
     rho = lattice.rho(f)
     u = lattice.u(f)
     feq = lattice.equilibrium(rho, u)
     shear_pre = lattice.shear_tensor(f)
     shear_eq_pre = lattice.shear_tensor(feq)
-    tau = 0.6
-    coll = Collision(lattice, tau)
-    f_post = coll(f)
+    f_post = collision(f)
     shear_post = lattice.shear_tensor(f_post)
     assert shear_post.cpu().numpy() == pytest.approx((shear_pre - 1 / tau * (shear_pre - shear_eq_pre)).cpu().numpy(),
                                                      abs=1e-5)
@@ -72,7 +68,10 @@ def test_collision_optimizes_pseudo_entropy(Collision, f_all_lattices):
             (Collision == KBCCollision3D and lattice.stencil != D3Q27))):
         pytest.skip()
     tau = 0.5003
-    coll_kbc = Collision(lattice, tau)
+    try:
+        coll_kbc = Collision(lattice, tau)
+    except LettuceCollisionNotDefined:
+        pytest.skip()
     coll_bgk = BGKCollision(lattice, tau)
     f_kbc = coll_kbc(f)
     f_bgk = coll_bgk(f)
@@ -88,7 +87,8 @@ def test_collision_fixpoint_2x_MRT(Transform, dtype_device):
     np.random.seed(1)  # arbitrary, but deterministic
     f = lattice.convert_to_tensor(np.random.random([lattice.Q] + [3] * lattice.D))
     f_old = copy(f)
-    collision = MRTCollision(lattice, Transform(lattice), np.array([0.5] * 9))
+    collision = MRTCollision(lattice, np.array([0.5] * 9), Transform(lattice))
     f = collision(collision(f))
     print(f.cpu().numpy(), f_old.cpu().numpy())
     assert f.cpu().numpy() == pytest.approx(f_old.cpu().numpy(), abs=1e-5)
+

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -83,6 +83,7 @@ def test_symmetry_group(symmetry_group):
     group = symmetry_group
     n_symmetries = {D1Q3: 2, D2Q9: 8, D3Q19: 48, D3Q27: 48}[group.stencil]
     assert len(group) == n_symmetries
+    assert group.permutations.shape == (n_symmetries, group.stencil.Q())
 
     # assert that it's a group:
     # contains the identity
@@ -108,5 +109,4 @@ def test_permutations(symmetry_group):
         perm2 = InverseSymmetry(g).permutation(symmetry_group.stencil)
         assert np.allclose(perm1[perm2], np.arange(symmetry_group.stencil.Q()))
         assert np.allclose(perm2[perm1], np.arange(symmetry_group.stencil.Q()))
-
 

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -2,7 +2,7 @@
 import pytest
 import numpy as np
 from lettuce.symmetry import *
-from lettuce import D1Q3, D2Q9, D3Q19, D3Q27
+from lettuce import D1Q3, D2Q9, D3Q19, D3Q27, Lattice
 
 
 def test_four_rotations(stencil):
@@ -110,3 +110,14 @@ def test_permutations(symmetry_group):
         assert np.allclose(perm1[perm2], np.arange(symmetry_group.stencil.Q()))
         assert np.allclose(perm2[perm1], np.arange(symmetry_group.stencil.Q()))
 
+
+def test_feq_equivariance(symmetry_group, dtype_device):
+    dtype, device = dtype_device
+    lattice = Lattice(symmetry_group.stencil, dtype=dtype, device=device)
+    feq = lambda f: lattice.equilibrium(lattice.rho(f), lattice.u(f))
+    f = lattice.convert_to_tensor(np.random.random([lattice.Q] + [3] * lattice.D))
+    for g in symmetry_group:
+        assert np.allclose(
+            feq(f[g.permutation(symmetry_group.stencil)]),
+            feq(f)[g.permutation(symmetry_group.stencil)],
+        )

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -1,0 +1,112 @@
+
+import pytest
+import numpy as np
+from lettuce.symmetry import *
+from lettuce import D1Q3, D2Q9, D3Q19, D3Q27
+
+
+def test_four_rotations(stencil):
+    for i in range(stencil.D()):
+        for j in range(i+1, stencil.D()):
+            assert are_symmetries_equal(
+                ChainedSymmetry(*([Rotation90(i, j)]*4)),
+                Identity(),
+                stencil=stencil
+            )
+            assert not are_symmetries_equal(
+                ChainedSymmetry(*([Rotation90(i, j)]*3)),
+                Identity(),
+                stencil=stencil
+            )
+
+
+def test_two_reflections(stencil):
+    for i in range(stencil.D()):
+        assert are_symmetries_equal(
+            ChainedSymmetry(*([Reflection(i)]*2)),
+            Identity(),
+            stencil=stencil
+        )
+        assert not are_symmetries_equal(
+            ChainedSymmetry(*([Reflection(i)]*3)),
+            Identity(),
+            stencil=stencil
+        )
+
+
+def test_two_reflections(stencil):
+    for i in range(stencil.D()):
+        assert are_symmetries_equal(
+            ChainedSymmetry(*([Reflection(i)]*2)),
+            Identity(),
+            stencil=stencil
+        )
+        assert not are_symmetries_equal(
+            ChainedSymmetry(*([Reflection(i)]*3)),
+            Identity(),
+            stencil=stencil
+        )
+
+
+def test_reflection_by_rotations(stencil):
+    for i in range(stencil.D()):
+        for j in range(i+1, stencil.D()):
+            assert are_symmetries_equal(
+                ChainedSymmetry(Rotation90(i, j), Rotation90(i, j)),
+                ChainedSymmetry(Reflection(i), Reflection(j)),
+                stencil=stencil
+            )
+
+
+def test_inverse(stencil):
+    for i in range(stencil.D()):
+        for j in range(i+1, stencil.D()):
+            assert are_symmetries_equal(
+                ChainedSymmetry(Rotation90(i, j), InverseSymmetry(Rotation90(i, j))),
+                Identity(),
+                stencil=stencil
+            )
+        assert are_symmetries_equal(
+            ChainedSymmetry(Reflection(i), InverseSymmetry(Reflection(i))),
+            Identity(),
+            stencil=stencil
+        )
+
+
+@pytest.fixture(scope="module")
+def symmetry_group(stencil):
+    group = SymmetryGroup(stencil)
+    return group
+
+
+def test_symmetry_group(symmetry_group):
+    group = symmetry_group
+    n_symmetries = {D1Q3: 2, D2Q9: 8, D3Q19: 48, D3Q27: 48}[group.stencil]
+    assert len(group) == n_symmetries
+
+    # assert that it's a group:
+    # contains the identity
+    assert Identity() in group
+    for s1 in group:
+        for s2 in group:
+            if s1 != s2:
+                # elements are unique
+                assert not are_symmetries_equal(s1, s2, group.stencil)
+        # contains the inverse
+        assert InverseSymmetry(s1) in group
+
+
+def test_permutations(symmetry_group):
+    for g in symmetry_group:
+        # symmetry operation is equal to the corresponding permutation
+        assert np.allclose(
+            g.forward(symmetry_group.stencil.e),
+            symmetry_group.stencil.e[g.permutation(symmetry_group.stencil), ...]
+        )
+        # inverse permutation of permutation is identity
+        perm1 = g.permutation(symmetry_group.stencil)
+        perm2 = InverseSymmetry(g).permutation(symmetry_group.stencil)
+        assert np.allclose(perm1[perm2], np.arange(symmetry_group.stencil.Q()))
+        assert np.allclose(perm2[perm1], np.arange(symmetry_group.stencil.Q()))
+
+

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -126,6 +126,7 @@ def test_feq_equivariance(symmetry_group, dtype_device):
 
 
 def test_collision_equivariance(symmetry_group, dtype_device, Collision):
+    """Test whether all collision models obey the lattice symmetries."""
     dtype, device = dtype_device
     lattice = Lattice(symmetry_group.stencil, dtype=dtype, device=device)
     f = lattice.convert_to_tensor(np.random.random([lattice.Q] + [3] * lattice.D))
@@ -140,5 +141,5 @@ def test_collision_equivariance(symmetry_group, dtype_device, Collision):
         assert torch.allclose(
             f_post_after_g,
             f_post[permutation],
-            atol=2e-5 if dtype == torch.float32 else 1e-6
+            atol=2e-5 if dtype == torch.float32 else 1e-7
         ), f"{g}; {(f_post_after_g - f_post[permutation]).norm()}"


### PR DESCRIPTION
This is a first attempt to formalize the incorporation of lattice symmetries into collision models. For now it mainly automates finding the symmetries of each stencil and converting them into the respective index permutations. The current version at least allows us to check if a collision model obeys all desired lattice symmetries (see the last test in test_symmetry.py)

The code for such a check would look like this:
```
import lettuce as lt
stencil = ... # some stencil
collision = ... # some collision model
f = ... # some f
symmetry_group = lt.SymmetryGroup(stencil)
for permutation in symmetry_group.permutations:
    assert torch.allclose(collision(f[permutation]), collision(f)[permutation])
```

## Breaking Change:
Swapped the order of `transform` and `relaxation_parameters` in the MRT collision model constructor. 

@McBs 