### PR TITLE
Remove experimental warning

### DIFF
--- a/lettuce/moments.py
+++ b/lettuce/moments.py
@@ -421,7 +421,6 @@ class D3Q27Hermite(Transform):
         return self.lattice.mv(self.inverse, m)
 
     def equilibrium(self, m):
-        warnings.warn("A second proof is requiered for this equilibrium @A.K. or @D.W..", ExperimentalWarning)
         meq = torch.zeros_like(m)
         rho = m[0]
         jx = m[1]


### PR DESCRIPTION
This PR removes an experimental warning within moment.py for D3Q27 moment transformation