### PR TITLE
Update A_first_example.ipynb

### DIFF
--- a/examples/A_first_example.ipynb
+++ b/examples/A_first_example.ipynb
@@ -170,7 +170,7 @@
     }
    ],
    "source": [
-    "u = flow.units.convert_velocity_to_pu(lattice.u(simulation.f)).numpy()\n",
+    "u = flow.units.convert_velocity_to_pu(lattice.u(simulation.f)).cpu().numpy()\n",
     "u_norm = np.linalg.norm(u,axis=0)\n",
     "plt.imshow(u_norm)\n",
     "plt.show()"


### PR DESCRIPTION
Otherwise, line 173 returns

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[9], line 1
----> 1 u = flow.units.convert_velocity_to_pu(lattice.u(simulation.f)).numpy()
      2 u_norm = np.linalg.norm(u,axis=0)
      3 plt.imshow(u_norm)

TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```