### PR TITLE
112 convergence tool should be run as a test

### DIFF
--- a/old_tests/test_flows.py
+++ b/old_tests/test_flows.py
@@ -8,35 +8,6 @@ from lettuce import Obstacle2D, Obstacle3D
 from lettuce.flows.poiseuille import PoiseuilleFlow2D
 from lettuce import Context
 
-# Flows to test
-INCOMPRESSIBLE_2D = [TaylorGreenVortex2D, CouetteFlow2D, PoiseuilleFlow2D, DoublyPeriodicShear2D, DecayingTurbulence]
-INCOMPRESSIBLE_3D = [TaylorGreenVortex3D, DecayingTurbulence]
-
-
-@pytest.mark.parametrize("_stencil", [D2Q9, D3Q27])
-def test_divergence(stencil, dtype_device):
-    dtype, device = dtype_device
-    lattice = Lattice(stencil, dtype=dtype, device=device)
-    flow = DecayingTurbulence(50, 1, 0.05, lattice=lattice, ic_energy=0.5)
-    collision = BGKCollision(lattice, tau=flow.units.relaxation_parameter_lu)
-    streaming = StandardStreaming(lattice)
-    simulation = Simulation(flow=flow, lattice=lattice, collision=collision, streaming=streaming)
-    ekin = flow.units.convert_incompressible_energy_to_pu(
-        torch.sum(lattice.incompressible_energy(simulation.f))) * flow.units.convert_length_to_pu(1.0) ** lattice.D
-
-    u0 = flow.units.convert_velocity_to_pu(lattice.u(simulation.f)[0])
-    u1 = flow.units.convert_velocity_to_pu(lattice.u(simulation.f)[1])
-    dx = flow.units.convert_length_to_pu(1.0)
-    grad_u0 = torch_gradient(u0, dx=dx, order=6).cpu().numpy()
-    grad_u1 = torch_gradient(u1, dx=dx, order=6).cpu().numpy()
-    divergence = np.sum(grad_u0[0] + grad_u1[1])
-
-    if lattice.D == 3:
-        u2 = flow.units.convert_velocity_to_pu(lattice.u(simulation.f)[2])
-        grad_u2 = torch_gradient(u2, dx=dx, order=6).cpu().numpy()
-        divergence += np.sum(grad_u2[2])
-    assert (flow.ic_energy == pytest.approx(lattice.convert_to_numpy(ekin), rel=1))
-    assert (0 == pytest.approx(divergence, abs=2e-3))
 
 
 @pytest.mark.parametrize("_stencil", [D2Q9, D3Q27])

--- a/tests/flow/test_divergence.py
+++ b/tests/flow/test_divergence.py
@@ -1,0 +1,34 @@
+from tests.common import *
+
+@pytest.mark.parametrize("stencil2d3d", [D2Q9(), D3Q27()])
+def test_divergence(stencil2d3d, fix_configuration):
+    device, dtype, use_native = fix_configuration
+    context = Context(device=device, dtype=dtype, use_native=use_native)
+    flow = DecayingTurbulence(context=context,
+                              resolution=[50] * stencil2d3d.d,
+                              reynolds_number=1,
+                              mach_number=0.05,
+                              ic_energy=0.5)
+    collision = BGKCollision(tau=flow.units.relaxation_parameter_lu)
+    simulation = Simulation(flow=flow,
+                            collision=collision,
+                            reporter=[])
+    ekin = (flow.units.convert_incompressible_energy_to_pu(
+        torch.sum(flow.incompressible_energy())) *
+            flow.units.convert_length_to_pu(1.0) ** stencil2d3d.d)
+
+    u0 = flow.u_pu[0]
+    u1 = flow.u_pu[1]
+    dx = flow.units.convert_length_to_pu(1.0)
+    grad_u0 = torch_gradient(u0, dx=dx, order=6).cpu().numpy()
+    grad_u1 = torch_gradient(u1, dx=dx, order=6).cpu().numpy()
+    divergence = np.sum(grad_u0[0] + grad_u1[1])
+
+    if stencil2d3d.d == 3:
+        u2 = flow.u_pu[2]
+        grad_u2 = torch_gradient(u2, dx=dx, order=6).cpu().numpy()
+        divergence += np.sum(grad_u2[2])
+    assert (flow.ic_energy ==
+            pytest.approx(context.convert_to_ndarray(ekin), rel=1))
+    assert (0 == pytest.approx(divergence, abs=2e-3))
+    

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -1,0 +1,42 @@
+from tests.common import *
+
+
+def test_convergence(fix_configuration):
+    """Use Taylor Green 2D for convergence test in diffusive scaling."""
+    device, dtype, use_native = fix_configuration
+    context = Context(device=device, dtype=dtype, use_native=use_native)
+
+    error_u_old = None
+    error_p_old = None
+    factor_u = None
+    factor_p = None
+    print(("{:>15} " * 6).format("resolution", "error (u)", "order (u)",
+                                 "error (p)", "order (p)", "MLUPS"))
+
+    for i in range(4, 9 if dtype==torch.float64 else 7):  # single
+        # precission does not converge as far
+        resolution = 2 ** i
+        mach_number = 8 / resolution
+
+        # Simulation
+        flow = TaylorGreenVortex(context, [resolution] * 2,
+                                 reynolds_number=10000,
+                                 mach_number=mach_number)
+        collision = BGKCollision(tau=flow.units.relaxation_parameter_lu)
+        error_reporter = ErrorReporter(flow.analytic_solution, interval=1,
+                                       out=None)
+
+        simulation = Simulation(flow, collision, [error_reporter])
+
+        mlups = simulation(10 * resolution)
+
+        error_u, error_p = np.mean(np.abs(error_reporter.out), axis=0).tolist()
+        factor_u = 0 if error_u_old is None else error_u_old / error_u
+        factor_p = 0 if error_p_old is None else error_p_old / error_p
+        error_u_old = error_u
+        error_p_old = error_p
+
+        print(f"{resolution:15} {error_u:15.2e} {factor_u / 2:15.1f} "
+              f"{error_p:15.2e} {factor_p / 2:15.1f} {mlups:15.2f}")
+    assert factor_u / 2 > (2 - 1e-6), "Velocity convergence failed"
+    assert factor_p / 2 > (1 - 1e-6), "Pressure convergence failed"


### PR DESCRIPTION
## Description

I copied the TGV test from lettuce/cli.py to tests/test_convergence.py, so that it is included in the pytest workflows.

## Checklist

 - [x] This pull request is associated to an issue
 - [x] This PR contains a description
 - [ ] ~Did you add a new method? If so, you need to~
   - [ ] ~add method description~
   - [ ] ~maybe mention class in the corresponding `__init__`~
   - [ ] ~add an example using the method in `examples/advanced_flows/` or `examples/simple_flows/`~
   - [x] add a test in `tests/`
 - [x] Add someone else as reviewer and wait for approval before merging.
