### PR TITLE
Update taylorgreen.py

### DIFF
--- a/lettuce/ext/_flows/taylorgreen.py
+++ b/lettuce/ext/_flows/taylorgreen.py
@@ -45,8 +45,8 @@ class TaylorGreenVortex(ExtFlow):
         return UnitConversion(
             reynolds_number=reynolds_number,
             mach_number=mach_number,
-            characteristic_length_lu=resolution[0] / 2 * 3.14159265359,
-            characteristic_length_pu=1,
+            characteristic_length_lu=resolution[0],
+            characteristic_length_pu=2 * 3.14159265359,
             characteristic_velocity_pu=1)
 
     @property


### PR DESCRIPTION
Corrects the unit converter definition to match Brachet’s formulation.
Previous commits introduced an incorrect definition, which is now resolved.