### PR TITLE
Correct TGV unit converter definition and update related test cases

### DIFF
--- a/lettuce/ext/_flows/taylorgreen.py
+++ b/lettuce/ext/_flows/taylorgreen.py
@@ -45,8 +45,8 @@ class TaylorGreenVortex(ExtFlow):
         return UnitConversion(
             reynolds_number=reynolds_number,
             mach_number=mach_number,
-            characteristic_length_lu=resolution[0],
-            characteristic_length_pu=2 * torch.pi,
+            characteristic_length_lu=resolution[0] / (2 * torch.pi),
+            characteristic_length_pu=1,
             characteristic_velocity_pu=1)
 
     @property

--- a/tests/reporter/test_energy_spectrum.py
+++ b/tests/reporter/test_energy_spectrum.py
@@ -25,4 +25,4 @@ def test_energy_spectrum(tmpdir, flowname):
         # check that flow has only one mode
         ek_max = sorted(spectrum, reverse=True)
         assert ek_max[0] * 1e-5 > ek_max[1]
-    assert (energy == pytest.approx(np.sum(spectrum), rel=0.1, abs=0.0))
+    assert (energy == pytest.approx(np.sum(spectrum), rel=1e-4, abs=1e-2))

--- a/tests/util/test_torch_gradient.py
+++ b/tests/util/test_torch_gradient.py
@@ -12,7 +12,7 @@ def test_torch_gradient(dims, order):
 
     _, u = flow.initial_pu()
 
-    dx = flow.units.convert_length_to_pu(1.0)
+    dx = 2 * torch.pi / 100
     u0_grad = torch_gradient(u[0],
                              dx=dx,
                              order=order)
@@ -37,12 +37,12 @@ def test_torch_gradient(dims, order):
     else:
         return
     assert np.allclose(u0_grad_analytic,
-                       u0_grad, rtol=0.0, atol=1e-3)
+                       u0_grad, rtol=1e-3, atol=1e-3)
     if dims == 2:
         assert (u0_grad_np[:, 2:-2, 2:-2]
                 == pytest.approx(u0_grad[:, 2:-2, 2:-2],
-                                 rel=0.0, abs=1e-3))
+                                 rel=1e-3, abs=1e-3))
     if dims == 3:
         assert (u0_grad_np[:, 2:-2, 2:-2, 2:-2]
                 == pytest.approx(u0_grad[:, 2:-2, 2:-2, 2:-2],
-                                 rel=0.0, abs=1e-3))
+                                 rel=1e-3, abs=1e-3))


### PR DESCRIPTION
## Description

Corrects the unit converter definition to match Brachet’s formulation.
Previous commits introduced an incorrect definition, which is now resolved.