### PR TITLE
fix: patch setuptools path traversal vulnerability in PackageIndex.download

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "packaging>=24.1",
     "pyevtk>=1.6.0",
     "pytest>=8.3.2",
-    "setuptools>=72.1.0",
+    "setuptools>=78.1.1",
     "torch>=2.6.0",
     "vtk>=9.5.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,7 +93,7 @@ pytest==8.3.2
     # via lettuce (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via matplotlib
-setuptools==72.1.0
+setuptools==80.9.0
     # via
     #   lettuce (pyproject.toml)
     #   torch

--- a/uv.lock
+++ b/uv.lock
@@ -218,7 +218,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=24.1" },
     { name = "pyevtk", specifier = ">=1.6.0" },
     { name = "pytest", specifier = ">=8.3.2" },
-    { name = "setuptools", specifier = ">=72.1.0" },
+    { name = "setuptools", specifier = ">=78.1.1" },
     { name = "torch", specifier = ">=2.6.0" },
     { name = "torch", marker = "(sys_platform == 'darwin' and extra == 'cpu') or (sys_platform == 'linux' and extra == 'cpu') or (sys_platform == 'win32' and extra == 'cpu')", specifier = ">=2.7.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "lettuce", extra = "cpu" } },
     { name = "torch", marker = "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'cpu'", specifier = ">=2.7.0" },
@@ -981,11 +981,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "72.1.0"
+version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/11/487b18cc768e2ae25a919f230417983c8d5afa1b6ee0abd8b6db0b89fa1d/setuptools-72.1.0.tar.gz", hash = "sha256:8d243eff56d095e5817f796ede6ae32941278f542e0f941867cc05ae52b162ec", size = 2419487, upload-time = "2024-07-29T15:11:43.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/58/e0ef3b9974a04ce9cde2a7a33881ddcb2d68450803745804545cdd8d258f/setuptools-72.1.0-py3-none-any.whl", hash = "sha256:5a03e1860cf56bb6ef48ce186b0e557fdba433237481a9a625176c2831be15d1", size = 2337965, upload-time = "2024-07-29T15:11:37.999Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

According to #257, setuptools had a path traversal vulnerability in `PackageIndex.download` that could lead to arbitrary file writes (similar to GHSA-r9hx-vwmv-q579). The issue was fixed upstream in version 78.1.1.