### PR TITLE
Update equilibrium_outlet_p.py to prevent torch-indexing warning

### DIFF
--- a/lettuce/ext/_boundary/equilibrium_outlet_p.py
+++ b/lettuce/ext/_boundary/equilibrium_outlet_p.py
@@ -61,8 +61,8 @@ class EquilibriumOutletP(AntiBounceBackOutlet):
             self.w = flow.torch_stencil.w[self.velocities]
 
     def __call__(self, flow: 'Flow'):
-        here = [slice(None)] + self.index
-        other = [slice(None)] + self.neighbor
+        here = tuple([slice(None)] + self.index)
+        other = tuple([slice(None)] + self.neighbor)
         rho = flow.rho()
         u = flow.u()
         rho_w = self.rho_outlet * torch.ones_like(rho[here])
@@ -75,13 +75,13 @@ class EquilibriumOutletP(AntiBounceBackOutlet):
     def make_no_streaming_mask(self, shape: List[int], context: 'Context'
                                ) -> Optional[torch.Tensor]:
         no_streaming_mask = context.zero_tensor(shape, dtype=bool)
-        no_streaming_mask[[np.setdiff1d(np.arange(shape[0]), self.velocities)]
-                          + self.index] = 1
+        no_streaming_mask[tuple([np.setdiff1d(np.arange(shape[0]), self.velocities)]
+                          + self.index)] = 1
         return no_streaming_mask
 
     def make_no_collision_mask(self, shape: List[int], context: 'Context'):
         no_collision_mask = context.zero_tensor(shape, dtype=torch.bool)
-        no_collision_mask[self.index] = 1
+        no_collision_mask[tuple(self.index)] = 1
         return no_collision_mask
 
     def native_available(self) -> bool:


### PR DESCRIPTION
## Description

Update `equilibrium_outlet_p.py` to prevent **torch-indexing warning:**
- current torch-version (2.9.1 in this case) issues a warning about the indices `here`, `other` and ` [np.setdiff1d(np.arange(shape[0]), self.velocities)] + self.index` being lists and having to be tuples (lists vs. tuples as indices).

closes #291 

### Further thought:
Some boundary-calls (equilibrium inlet, equilirium outlet etc.) might be inefficient and could be improved by torch-batch-indices!

## Checklist

 - [x] This pull request is associated to an issue
 - [x] This PR contains a description
 - [x] Add someone else as reviewer and wait for approval before merging.
