### PR TITLE
Update observable_reporter.py

### DIFF
--- a/lettuce/ext/_reporter/observable_reporter.py
+++ b/lettuce/ext/_reporter/observable_reporter.py
@@ -179,7 +179,8 @@ class ObservableReporter(Reporter):
         self.observable = observable
         self.out = [] if out is None else out
         self._parameter_name = observable.__class__.__name__
-        print('steps    ', 'time    ', self._parameter_name)
+        if out is not None:
+            print('steps    ', 'time    ', self._parameter_name)
 
     def __call__(self, simulation: 'Simulation'):
         if simulation.flow.i % self.interval == 0:


### PR DESCRIPTION
## Description

let the __init__.py not print `'steps    ', 'time    ', self._parameter_name` if `out `is set to a file. Quality of Life improvement to keep stdout clean,

closes #293 

## Checklist

 - [x] This pull request is associated to an issue
 - [x] This PR contains a description
 - [x] Add someone else as reviewer and wait for approval before merging.
